### PR TITLE
feat: add "about us" template

### DIFF
--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -1,0 +1,13 @@
+header {
+    position: relative;
+    z-index: 10;
+}
+
+.page-template-about-us .entry-content .wp-block-cover {
+    margin-top: -150px;
+    padding-top: 200px;
+}
+
+.transform-top-50 {
+    transform: translateY(-50%);
+}

--- a/functions.php
+++ b/functions.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SkgMeetup\Theme;
+
+add_action(
+    'after_setup_theme',
+    static function (): void {
+        require __DIR__ . '/src/Assets.php';
+
+        (new Assets())->boot();
+    }
+);

--- a/parts/header.html
+++ b/parts/header.html
@@ -1,7 +1,11 @@
-<!-- wp:group {"layout":{"type":"constrained","contentSize":"1200px"}} -->
-<div class="wp-block-group"><!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","right":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50"}}},"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)"><!-- wp:site-logo /-->
+<!-- wp:group {"tagName":"header","layout":{"type":"constrained","contentSize":"1200px"}} -->
+<header class="wp-block-group">
+    <!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","right":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50"}}},"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
+    <div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">
+        <!-- wp:site-logo {"shouldSyncIcon":true} /-->
 
-<!-- wp:navigation {"ref":56,"layout":{"type":"flex","justifyContent":"right"}} /--></div>
-<!-- /wp:group --></div>
+        <!-- wp:navigation {"ref":20,"layout":{"type":"flex","justifyContent":"right"}} /-->
+    </div>
+    <!-- /wp:group -->
+</header>
 <!-- /wp:group -->

--- a/patterns/about-us.php
+++ b/patterns/about-us.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Title: About us
+ * Slug: skg-meetup-theme/about-us
+ * Block Types: core/post-content
+ * Post Types: page
+ * Categories: posts
+ */
+
+?>
+
+<!-- wp:cover {"overlayColor":"grey-100","isDark":false,"className":"alignfull is-light has-custom-content-position is-position-top-center"} -->
+<div class="wp-block-cover is-light alignfull has-custom-content-position is-position-top-center"><span aria-hidden="true" class="wp-block-cover__background has-grey-100-background-color has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:group {"layout":{"type":"default"}} -->
+        <div class="wp-block-group"><!-- wp:paragraph {"align":"center","style":{"elements":{"link":{"color":{"text":"var:preset|color|blue"}}}},"textColor":"blue"} -->
+            <p class="has-text-align-center has-blue-color has-text-color has-link-color"><strong>What's new</strong></p>
+            <!-- /wp:paragraph -->
+
+            <!-- wp:heading {"textAlign":"center","level":1,"style":{"elements":{"link":{"color":{"text":"var:preset|color|grey-900"}}}},"textColor":"grey-900"} -->
+            <h1 class="wp-block-heading has-text-align-center has-grey-900-color has-text-color has-link-color">Finish what you started today before you forget to do it.</h1>
+            <!-- /wp:heading -->
+
+            <!-- wp:paragraph {"align":"center","style":{"elements":{"link":{"color":{"text":"var:preset|color|grey-700"}}}},"textColor":"grey-700"} -->
+            <p class="has-text-align-center has-grey-700-color has-text-color has-link-color">Correct annotation helps your customers find their way around new features. Getting familiar with the project is the first step towards development.</p>
+            <!-- /wp:paragraph -->
+
+            <!-- wp:spacer {"height":"30px"} -->
+            <div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
+            <!-- /wp:spacer -->
+
+            <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
+            <div class="wp-block-buttons"><!-- wp:button {"textAlign":"center"} -->
+                <div class="wp-block-button"><a class="wp-block-button__link has-text-align-center wp-element-button">Try for free</a></div>
+                <!-- /wp:button -->
+
+                <!-- wp:button {"className":"is-style-outline"} -->
+                <div class="wp-block-button is-style-outline"><a class="wp-block-button__link wp-element-button">Learn more</a></div>
+                <!-- /wp:button --></div>
+            <!-- /wp:buttons -->
+
+            <!-- wp:spacer -->
+            <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
+            <!-- /wp:spacer --></div>
+        <!-- /wp:group --></div></div>
+<!-- /wp:cover -->
+
+<!-- wp:gallery {"linkTo":"none","className":"transform-top-50"} -->
+<figure class="wp-block-gallery has-nested-images columns-default is-cropped transform-top-50"></figure>
+<!-- /wp:gallery -->
+
+<!-- wp:spacer -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:media-text {"mediaPosition":"right","verticalAlignment":"top"} -->
+<div class="wp-block-media-text has-media-on-the-right is-stacked-on-mobile is-vertically-aligned-top"><div class="wp-block-media-text__content"><!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|blue"}}}},"textColor":"blue","fontSize":"xs"} -->
+        <p class="has-blue-color has-text-color has-link-color has-xs-font-size"><strong>What's new at Shuffle</strong></p>
+        <!-- /wp:paragraph -->
+
+        <!-- wp:heading -->
+        <h2 class="wp-block-heading">Expand your brand with this excellent extension tool</h2>
+        <!-- /wp:heading -->
+
+        <!-- wp:paragraph {"fontSize":"lg"} -->
+        <p class="has-lg-font-size">With this tool, you will get much better results at work and develop new skills. Will you take the risk of trying the latest version of our application?</p>
+        <!-- /wp:paragraph -->
+
+        <!-- wp:paragraph {"fontSize":"lg"} -->
+        <p class="has-lg-font-size"><a href="#">Learn more</a></p>
+        <!-- /wp:paragraph --></div><figure class="wp-block-media-text__media"></figure></div>
+<!-- /wp:media-text -->
+
+<!-- wp:spacer -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:gallery {"linkTo":"none"} -->
+<figure class="wp-block-gallery has-nested-images columns-default is-cropped"></figure>
+<!-- /wp:gallery -->
+
+<!-- wp:spacer -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:media-text {"verticalAlignment":"top"} -->
+<div class="wp-block-media-text is-stacked-on-mobile is-vertically-aligned-top"><figure class="wp-block-media-text__media"></figure><div class="wp-block-media-text__content"><!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|blue"}}}},"textColor":"blue","fontSize":"xs"} -->
+        <p class="has-blue-color has-text-color has-link-color has-xs-font-size"><strong>What's new at Shuffle</strong></p>
+        <!-- /wp:paragraph -->
+
+        <!-- wp:heading -->
+        <h2 class="wp-block-heading">Expand your brand with this excellent extension tool</h2>
+        <!-- /wp:heading -->
+
+        <!-- wp:paragraph {"fontSize":"lg"} -->
+        <p class="has-lg-font-size">With this tool, you will get much better results at work and develop new skills. Will you take the risk of trying the latest version of our application?</p>
+        <!-- /wp:paragraph -->
+
+        <!-- wp:paragraph {"fontSize":"lg"} -->
+        <p class="has-lg-font-size"><a href="#">Learn more</a></p>
+        <!-- /wp:paragraph --></div></div>
+<!-- /wp:media-text -->

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SkgMeetup\Theme;
+
+class Assets
+{
+    public function boot(): void {
+        add_action('wp_enqueue_scripts', [$this, 'load']);
+    }
+
+    public function load(): void
+    {
+        wp_enqueue_style(
+            'skg-meetup-theme-main',
+            get_theme_file_uri('assets/styles/main.css')
+        );
+    }
+}

--- a/templates/about-us.html
+++ b/templates/about-us.html
@@ -1,0 +1,3 @@
+<!-- wp:template-part {"slug":"header","theme":"skg-meetup-theme","area":"uncategorized"} /-->
+
+<!-- wp:post-content {"layout":{"type":"constrained"}} /-->

--- a/theme.json
+++ b/theme.json
@@ -6,7 +6,7 @@
 	],
 	"settings": {
 		"layout": {
-			"contentSize": "750px",
+			"contentSize": "1024px",
 			"wideSize": "1200px"
 		},
 		"spacing": {


### PR DESCRIPTION
- Adds about us page pattern
- Adds about us page template (no footer)
- Updates header pattern to use `header` instead of a plain `div`
- Adds support for custom CSS
- Adds CSS for header overlapping the entry cover in about-us.
- Updates the content size in `theme.json` to better align with ZEUS design